### PR TITLE
[FEATURE] Add Permalink to news when importing

### DIFF
--- a/Classes/Domain/Model/NewsInstagram.php
+++ b/Classes/Domain/Model/NewsInstagram.php
@@ -16,6 +16,8 @@ class NewsInstagram extends News
 
     protected string $mediaType = '';
 
+    protected string $permalink = '';
+
     public function getInstagramId(): string
     {
         return $this->instagramId;
@@ -50,5 +52,15 @@ class NewsInstagram extends News
         $this->mediaType = $mediaType;
 
         return $this;
+    }
+
+    public function getPermalink(): string
+    {
+        return $this->permalink;
+    }
+
+    public function setPermalink(string $permalink): void
+    {
+        $this->permalink = $permalink;
     }
 }

--- a/Classes/Service/PostUpserter.php
+++ b/Classes/Service/PostUpserter.php
@@ -73,7 +73,8 @@ class PostUpserter
         $newsItem
             ->setInstagramId($dto->getId())
             ->setPostedBy($apiClient->getFeed()->getUsername())
-            ->setMediaType($dto->getMediaType());
+            ->setMediaType($dto->getMediaType())
+            ->setPermalink($dto->getPermalink());
 
         /** @var \DateTimeImmutable $postedAt */
         $postedAt = $dto->getTimestamp();

--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -32,12 +32,20 @@ $fields = [
             'size' => 30,
         ],
     ],
+    'permalink' => [
+        'exclude' => 1,
+        'label' => 'Permalink',
+        'config' => [
+            'type' => 'input',
+            'size' => 30,
+        ],
+    ],
 ];
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette(
     'tx_news_domain_model_news',
     'tx_instagram2news_fields',
-    'instagram_id, posted_by, media_type'
+    'instagram_id, posted_by, media_type, permalink'
 );
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tx_news_domain_model_news', $fields);

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan": "^1.4",
 		"typo3/coding-standards": "^0.6.1",
-		"typo3/testing-framework": "^6.16"
+		"typo3/testing-framework": "^8"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,7 +8,6 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\GeorgRinger\News\Domain\Model\New
     'className' => \DSKZPT\Instagram2News\Domain\Model\NewsInstagram::class,
 ];
 
-
 //\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\Object\Container\Container::class)
 //    ->registerImplementation(
 //        \GeorgRinger\News\Domain\Model\News::class,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -6,4 +6,5 @@ CREATE TABLE tx_news_domain_model_news
 	instagram_id varchar(255) DEFAULT '' NOT NULL,
 	posted_by    varchar(255) DEFAULT '' NOT NULL,
 	media_type   varchar(255) DEFAULT '' NOT NULL,
+	permalink   varchar(255) DEFAULT '' NOT NULL,
 );


### PR DESCRIPTION
This will add new field to imported News, with permalink from Instagram to reference to this Post.
It will not break the functionality and is not breaking.

- added new TCA field "permalink"
- updated "typo3/testing-framework" to work with TYPO3 v12